### PR TITLE
Fix: Prioritize stderr when Codex structured markers detected

### DIFF
--- a/scripts/verify-stderr-resolution.ts
+++ b/scripts/verify-stderr-resolution.ts
@@ -1,0 +1,142 @@
+#!/usr/bin/env tsx
+
+/**
+ * Manual verification script for US-001: Restore Structured Codex Output in MCP
+ * Task: T-018 - Create manual verification script
+ *
+ * This script demonstrates that the stderr-first resolution logic works correctly.
+ * It executes a shell command that writes structured output to stderr and verifies
+ * that the executeCommand function correctly identifies and returns the structured
+ * content from stderr instead of stdout.
+ *
+ * Usage:
+ *   npx tsx scripts/verify-stderr-resolution.ts
+ *
+ *   Or with npm:
+ *   npm run verify
+ *
+ * Expected behavior:
+ *   - Script executes a command that writes structured output to stderr
+ *   - Result should contain the structured sections (--------/thinking/codex markers)
+ *   - This proves stderr-first resolution is working as designed
+ *   - The script will output PASS if structured markers are detected in the result
+ *
+ * Background:
+ *   US-001 fixed an issue where Codex CLI output was not being captured correctly
+ *   in non-TTY (MCP server) contexts. The fix implements stderr-first resolution:
+ *   when structured output markers are detected in stderr, use stderr; otherwise
+ *   fallback to stdout for backward compatibility.
+ */
+
+import { executeCommand } from '../src/utils/commandExecutor.js';
+
+async function verify(): Promise<void> {
+  console.log('='.repeat(70));
+  console.log('US-001 Manual Verification: Stderr-First Resolution');
+  console.log('='.repeat(70));
+  console.log();
+
+  // Test 1: Verify stderr with structured markers is used
+  console.log('Test 1: Structured output to stderr');
+  console.log('-'.repeat(70));
+
+  const structuredOutput = `--------
+thinking: This is the reasoning section where Codex analyzes the request
+--------
+codex: This is the actual response from Codex
+--------`;
+
+  try {
+    const result = await executeCommand(
+      'sh',
+      ['-c', `echo "${structuredOutput}" >&2`],
+      undefined,
+      5000
+    );
+
+    console.log('Command executed successfully');
+    console.log();
+    console.log('Result received:');
+    console.log(result);
+    console.log();
+
+    const hasThinking = result.includes('thinking');
+    const hasCodex = result.includes('codex');
+    const hasDivider = result.includes('--------');
+
+    console.log('Verification checks:');
+    console.log(`  - Contains 'thinking' section: ${hasThinking ? '✓' : '✗'}`);
+    console.log(`  - Contains 'codex' section: ${hasCodex ? '✓' : '✗'}`);
+    console.log(`  - Contains '--------' dividers: ${hasDivider ? '✓' : '✗'}`);
+    console.log();
+
+    if (hasThinking && hasCodex && hasDivider) {
+      console.log('Status: PASS ✓');
+      console.log('Stderr-first resolution is working correctly!');
+    } else {
+      console.log('Status: FAIL ✗');
+      console.log('Structured markers not found in result.');
+      process.exit(1);
+    }
+  } catch (error) {
+    console.error('Test 1 failed with error:', error);
+    process.exit(1);
+  }
+
+  console.log();
+  console.log('-'.repeat(70));
+  console.log();
+
+  // Test 2: Verify fallback to stdout when no structured markers
+  console.log('Test 2: Fallback to stdout (no structured markers)');
+  console.log('-'.repeat(70));
+
+  try {
+    const result = await executeCommand(
+      'echo',
+      ['Hello from stdout'],
+      undefined,
+      5000
+    );
+
+    console.log('Command executed successfully');
+    console.log();
+    console.log('Result received:');
+    console.log(result);
+    console.log();
+
+    const hasExpectedOutput = result.includes('Hello from stdout');
+    const hasNoStructuredMarkers = !result.includes('--------') &&
+                                   !result.includes('thinking') &&
+                                   !result.includes('codex');
+
+    console.log('Verification checks:');
+    console.log(`  - Contains expected stdout text: ${hasExpectedOutput ? '✓' : '✗'}`);
+    console.log(`  - No structured markers present: ${hasNoStructuredMarkers ? '✓' : '✗'}`);
+    console.log();
+
+    if (hasExpectedOutput && hasNoStructuredMarkers) {
+      console.log('Status: PASS ✓');
+      console.log('Stdout fallback is working correctly!');
+    } else {
+      console.log('Status: FAIL ✗');
+      console.log('Stdout fallback behavior incorrect.');
+      process.exit(1);
+    }
+  } catch (error) {
+    console.error('Test 2 failed with error:', error);
+    process.exit(1);
+  }
+
+  console.log();
+  console.log('='.repeat(70));
+  console.log('All tests passed! ✓');
+  console.log('US-001 stderr-first resolution is working as designed.');
+  console.log('='.repeat(70));
+}
+
+// Execute verification
+verify().catch((error) => {
+  console.error('Verification script failed:', error);
+  process.exit(1);
+});

--- a/src/utils/__tests__/commandExecutor.test.ts
+++ b/src/utils/__tests__/commandExecutor.test.ts
@@ -1,0 +1,436 @@
+import { describe, it, expect } from 'vitest';
+import { hasStructuredMarkers, executeCommand } from '../commandExecutor.js';
+
+describe('hasStructuredMarkers', () => {
+  describe('individual marker detection', () => {
+    it('should detect -------- divider marker', () => {
+      expect(hasStructuredMarkers('some text -------- more text')).toBe(true);
+    });
+
+    it('should detect thinking marker', () => {
+      expect(hasStructuredMarkers('thinking: some analysis')).toBe(true);
+    });
+
+    it('should detect codex marker', () => {
+      expect(hasStructuredMarkers('codex output here')).toBe(true);
+    });
+  });
+
+  describe('marker position variations', () => {
+    it('should detect marker at the start of text', () => {
+      expect(hasStructuredMarkers('-------- content')).toBe(true);
+      expect(hasStructuredMarkers('thinking analysis')).toBe(true);
+      expect(hasStructuredMarkers('codex result')).toBe(true);
+    });
+
+    it('should detect marker at the end of text', () => {
+      expect(hasStructuredMarkers('content --------')).toBe(true);
+      expect(hasStructuredMarkers('analysis thinking')).toBe(true);
+      expect(hasStructuredMarkers('result codex')).toBe(true);
+    });
+
+    it('should detect marker in the middle of text', () => {
+      expect(hasStructuredMarkers('before -------- after')).toBe(true);
+      expect(hasStructuredMarkers('before thinking after')).toBe(true);
+      expect(hasStructuredMarkers('before codex after')).toBe(true);
+    });
+  });
+
+  describe('multiple markers', () => {
+    it('should detect when multiple markers are present', () => {
+      expect(hasStructuredMarkers('-------- thinking codex')).toBe(true);
+      expect(hasStructuredMarkers('thinking -------- output')).toBe(true);
+      expect(hasStructuredMarkers('codex -------- thinking')).toBe(true);
+    });
+
+    it('should detect when all three markers are present', () => {
+      expect(hasStructuredMarkers('-------- thinking: analysis codex: result')).toBe(true);
+    });
+
+    it('should detect when the same marker appears multiple times', () => {
+      expect(hasStructuredMarkers('-------- section -------- another --------')).toBe(true);
+      expect(hasStructuredMarkers('thinking one thinking two thinking three')).toBe(true);
+      expect(hasStructuredMarkers('codex start codex middle codex end')).toBe(true);
+    });
+  });
+
+  describe('negative cases', () => {
+    it('should return false for text without any markers', () => {
+      expect(hasStructuredMarkers('plain text without markers')).toBe(false);
+    });
+
+    it('should return false for empty string', () => {
+      expect(hasStructuredMarkers('')).toBe(false);
+    });
+
+    it('should return false for whitespace-only text', () => {
+      expect(hasStructuredMarkers('   ')).toBe(false);
+      expect(hasStructuredMarkers('\t\n')).toBe(false);
+    });
+
+    it('should return false for words that do not contain markers', () => {
+      expect(hasStructuredMarkers('codec information')).toBe(false);
+      expect(hasStructuredMarkers('------')).toBe(false); // only 6 dashes
+    });
+
+    it('should return false for partial marker matches', () => {
+      expect(hasStructuredMarkers('think')).toBe(false);
+      expect(hasStructuredMarkers('code')).toBe(false);
+      expect(hasStructuredMarkers('---')).toBe(false);
+    });
+  });
+
+  describe('real-world examples', () => {
+    it('should detect markers in typical Codex CLI output format', () => {
+      const typicalOutput = `--------
+thinking: Analyzing the request...
+codex: Here is the response`;
+      expect(hasStructuredMarkers(typicalOutput)).toBe(true);
+    });
+
+    it('should detect markers in multiline structured output', () => {
+      const multilineOutput = `
+Header section
+--------
+thinking: Processing the query
+performing analysis
+--------
+codex: Final output
+`;
+      expect(hasStructuredMarkers(multilineOutput)).toBe(true);
+    });
+
+    it('should detect thinking section in reasoning output', () => {
+      const reasoningOutput = 'thinking: Let me break this down step by step...';
+      expect(hasStructuredMarkers(reasoningOutput)).toBe(true);
+    });
+
+    it('should detect codex identifier in final output', () => {
+      const codexOutput = 'codex: The answer is 42';
+      expect(hasStructuredMarkers(codexOutput)).toBe(true);
+    });
+
+    it('should handle output with only dividers', () => {
+      const dividerOutput = '--------\nSection 1\n--------\nSection 2\n--------';
+      expect(hasStructuredMarkers(dividerOutput)).toBe(true);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should handle markers with surrounding whitespace', () => {
+      expect(hasStructuredMarkers('  --------  ')).toBe(true);
+      expect(hasStructuredMarkers('  thinking  ')).toBe(true);
+      expect(hasStructuredMarkers('  codex  ')).toBe(true);
+    });
+
+    it('should handle markers within larger words (substring match)', () => {
+      // Note: The function uses .includes(), so it will match substrings
+      expect(hasStructuredMarkers('rethinking the approach')).toBe(true);
+      expect(hasStructuredMarkers('unthinking')).toBe(true);
+      expect(hasStructuredMarkers('codexample')).toBe(true);
+    });
+
+    it('should handle markers in mixed case text', () => {
+      // Note: The function is case-sensitive, so these should NOT match
+      expect(hasStructuredMarkers('THINKING')).toBe(false);
+      expect(hasStructuredMarkers('CODEX')).toBe(false);
+      expect(hasStructuredMarkers('Thinking')).toBe(false);
+      expect(hasStructuredMarkers('Codex')).toBe(false);
+    });
+
+    it('should handle very long strings with markers', () => {
+      const longString = 'a'.repeat(10000) + 'thinking' + 'b'.repeat(10000);
+      expect(hasStructuredMarkers(longString)).toBe(true);
+    });
+
+    it('should handle newlines and special characters', () => {
+      expect(hasStructuredMarkers('\n--------\n')).toBe(true);
+      expect(hasStructuredMarkers('\tthinking\t')).toBe(true);
+      expect(hasStructuredMarkers('codex\r\n')).toBe(true);
+    });
+
+    it('should handle Unicode and special characters in text', () => {
+      expect(hasStructuredMarkers('Hello 🌍 -------- world')).toBe(true);
+      expect(hasStructuredMarkers('思考 thinking 分析')).toBe(true);
+      expect(hasStructuredMarkers('résultat codex données')).toBe(true);
+    });
+  });
+
+  describe('performance and boundary conditions', () => {
+    it('should handle extremely short strings', () => {
+      expect(hasStructuredMarkers('c')).toBe(false);
+      expect(hasStructuredMarkers('co')).toBe(false);
+      expect(hasStructuredMarkers('cod')).toBe(false);
+      expect(hasStructuredMarkers('code')).toBe(false);
+      expect(hasStructuredMarkers('codex')).toBe(true);
+    });
+
+    it('should handle strings with only the marker', () => {
+      expect(hasStructuredMarkers('--------')).toBe(true);
+      expect(hasStructuredMarkers('thinking')).toBe(true);
+      expect(hasStructuredMarkers('codex')).toBe(true);
+    });
+
+    it('should handle concatenated markers without spaces', () => {
+      expect(hasStructuredMarkers('--------thinkingcodex')).toBe(true);
+      expect(hasStructuredMarkers('thinkingcodex--------')).toBe(true);
+      expect(hasStructuredMarkers('codex--------thinking')).toBe(true);
+    });
+  });
+});
+
+describe('executeCommand integration tests', () => {
+  describe('stderr-first resolution with structured markers', () => {
+    it('should resolve with stderr when structured markers present', async () => {
+      // Use shell to write structured output to stderr
+      const result = await executeCommand(
+        'sh',
+        ['-c', 'echo "--------\nthinking: test analysis\ncodex: result" >&2'],
+        undefined,
+        5000
+      );
+
+      expect(result).toContain('--------');
+      expect(result).toContain('thinking: test analysis');
+      expect(result).toContain('codex: result');
+    });
+
+    it('should resolve with stderr when only divider marker present', async () => {
+      const result = await executeCommand(
+        'sh',
+        ['-c', 'echo "--------\nSection 1\n--------\nSection 2" >&2'],
+        undefined,
+        5000
+      );
+
+      expect(result).toContain('--------');
+      expect(result).toContain('Section 1');
+      expect(result).toContain('Section 2');
+    });
+
+    it('should resolve with stderr when only thinking marker present', async () => {
+      const result = await executeCommand(
+        'sh',
+        ['-c', 'echo "thinking: analyzing the request" >&2'],
+        undefined,
+        5000
+      );
+
+      expect(result).toContain('thinking: analyzing the request');
+    });
+
+    it('should resolve with stderr when only codex marker present', async () => {
+      const result = await executeCommand(
+        'sh',
+        ['-c', 'echo "codex: final output" >&2'],
+        undefined,
+        5000
+      );
+
+      expect(result).toContain('codex: final output');
+    });
+  });
+
+  describe('stdout fallback when no markers present', () => {
+    it('should fallback to stdout when no markers in output', async () => {
+      const result = await executeCommand(
+        'echo',
+        ['plain output without markers'],
+        undefined,
+        5000
+      );
+
+      expect(result).toBe('plain output without markers');
+    });
+
+    it('should fallback to stdout when stderr has no markers', async () => {
+      // Write to both stdout and stderr, but only stdout has content without markers
+      const result = await executeCommand(
+        'sh',
+        ['-c', 'echo "stdout content"; echo "stderr without markers" >&2'],
+        undefined,
+        5000
+      );
+
+      expect(result).toBe('stdout content');
+    });
+
+    it('should handle command with only stdout output', async () => {
+      const result = await executeCommand(
+        'sh',
+        ['-c', 'echo "only stdout"'],
+        undefined,
+        5000
+      );
+
+      expect(result).toBe('only stdout');
+    });
+  });
+
+  describe('empty stderr edge case', () => {
+    it('should fallback to stdout when stderr is empty after trimming', async () => {
+      // Command writes to stdout but stderr is empty/whitespace
+      const result = await executeCommand(
+        'echo',
+        ['fallback to this'],
+        undefined,
+        5000
+      );
+
+      expect(result).toBe('fallback to this');
+    });
+
+    it('should fallback to stdout when stderr has only whitespace despite markers', async () => {
+      // This tests the T-011 edge case: stderr has markers but is empty after trimming
+      // We write structured markers but only whitespace to stderr, and content to stdout
+      const result = await executeCommand(
+        'sh',
+        ['-c', 'echo "stdout content"; echo "   " >&2'],
+        undefined,
+        5000
+      );
+
+      expect(result).toBe('stdout content');
+    });
+
+    it('should handle both streams empty', async () => {
+      const result = await executeCommand(
+        'sh',
+        ['-c', 'true'],
+        undefined,
+        5000
+      );
+
+      expect(result).toBe('');
+    });
+  });
+
+  describe('mixed output scenarios', () => {
+    it('should prefer stderr with markers over stdout without markers', async () => {
+      const result = await executeCommand(
+        'sh',
+        ['-c', 'echo "stdout plain"; echo "--------\ncodex: stderr structured" >&2'],
+        undefined,
+        5000
+      );
+
+      expect(result).toContain('--------');
+      expect(result).toContain('codex: stderr structured');
+      expect(result).not.toContain('stdout plain');
+    });
+
+    it('should handle multiline structured output in stderr', async () => {
+      const command = `echo "--------
+thinking: First step
+thinking: Second step
+--------
+codex: Final result" >&2`;
+
+      const result = await executeCommand(
+        'sh',
+        ['-c', command],
+        undefined,
+        5000
+      );
+
+      expect(result).toContain('--------');
+      expect(result).toContain('thinking: First step');
+      expect(result).toContain('thinking: Second step');
+      expect(result).toContain('codex: Final result');
+    });
+
+    it('should handle real-world Codex CLI output format', async () => {
+      const codexLikeOutput = `--------
+thinking: Analyzing the request...
+thinking: Processing query components...
+--------
+codex: Here is the response
+tokens: 150`;
+
+      const result = await executeCommand(
+        'sh',
+        ['-c', `echo "${codexLikeOutput}" >&2`],
+        undefined,
+        5000
+      );
+
+      expect(result).toContain('--------');
+      expect(result).toContain('thinking: Analyzing the request');
+      expect(result).toContain('codex: Here is the response');
+      expect(result).toContain('tokens: 150');
+    });
+  });
+
+  describe('error handling', () => {
+    it('should reject on non-zero exit code with stderr message', async () => {
+      await expect(
+        executeCommand(
+          'sh',
+          ['-c', 'echo "error message" >&2; exit 1'],
+          undefined,
+          5000
+        )
+      ).rejects.toThrow('Command failed with exit code 1: error message');
+    });
+
+    it('should reject with "Unknown error" when stderr is empty on failure', async () => {
+      await expect(
+        executeCommand(
+          'sh',
+          ['-c', 'exit 42'],
+          undefined,
+          5000
+        )
+      ).rejects.toThrow('Command failed with exit code 42: Unknown error');
+    });
+
+    it('should reject on command not found', async () => {
+      await expect(
+        executeCommand(
+          'nonexistent-command-xyz',
+          [],
+          undefined,
+          5000
+        )
+      ).rejects.toThrow('Codex CLI not found');
+    });
+  });
+
+  describe('progress callback integration', () => {
+    it('should call onProgress with stderr content when markers detected', async () => {
+      const progressUpdates: string[] = [];
+      const onProgress = (newOutput: string) => {
+        progressUpdates.push(newOutput);
+      };
+
+      await executeCommand(
+        'sh',
+        ['-c', 'echo "thinking: step 1" >&2; sleep 0.1; echo "codex: result" >&2'],
+        onProgress,
+        5000
+      );
+
+      // Progress callback should have been called with stderr content
+      expect(progressUpdates.length).toBeGreaterThan(0);
+      const allProgress = progressUpdates.join('');
+      expect(allProgress).toContain('thinking');
+    });
+
+    it('should not call onProgress for stdout when no markers present', async () => {
+      const progressUpdates: string[] = [];
+      const onProgress = (newOutput: string) => {
+        progressUpdates.push(newOutput);
+      };
+
+      await executeCommand(
+        'sh',
+        ['-c', 'echo "plain output"'],
+        onProgress,
+        5000
+      );
+
+      // Progress callback should not be called for plain stdout (T-005 requirement)
+      expect(progressUpdates.length).toBe(0);
+    });
+  });
+});

--- a/src/utils/commandExecutor.ts
+++ b/src/utils/commandExecutor.ts
@@ -1,6 +1,23 @@
 import { spawn } from "child_process";
 import { Logger } from "./logger.js";
 
+/**
+ * Detects if a string contains structured output markers from Codex.
+ *
+ * Structured output markers include:
+ * - `--------` (section divider)
+ * - `thinking` (reasoning section)
+ * - `codex` (output identifier)
+ *
+ * @param text - The text to check for structured output markers
+ * @returns true if any structured marker is found, false otherwise
+ */
+export function hasStructuredMarkers(text: string): boolean {
+  return text.includes('--------') ||
+         text.includes('thinking') ||
+         text.includes('codex');
+}
+
 export async function executeCommand(
   command: string,
   args: string[],
@@ -18,11 +35,19 @@ export async function executeCommand(
     });
 
     let stdout = "";
-    let stderr = "";
+    // stderr accumulates error output as a string buffer, verified in T-003
+    let stderr: string = "";
     let isResolved = false;
     let lastReportedLength = 0;
+    let lastReportedLengthStderr = 0;
     
     // Set up timeout if specified
+    // T-014: Timeout mechanism verified compatible with T-007/T-011 stream selection changes
+    // - Timeout sets isResolved=true BEFORE killing process (line 49)
+    // - Stream selection occurs in close handler which checks isResolved first (line 114)
+    // - Once timeout fires, close handler's stream selection logic never executes
+    // - Process termination (kill) happens before any resolution path is reached
+    // - Timeout operates at higher level than stream selection, ensuring proper precedence
     let timeoutHandle: NodeJS.Timeout | undefined;
     if (timeout) {
       timeoutHandle = setTimeout(() => {
@@ -36,28 +61,42 @@ export async function executeCommand(
     }
 
     childProcess.stdout.on("data", (data) => {
+      // Keep accumulating stdout buffer - needed for fallback logic in T-007
       stdout += data.toString();
-      
-      // Report new content if callback provided
+
+      // DISABLED: stdout progress reporting (T-005)
+      // Structured output comes through stderr in non-TTY mode.
+      // Stdout progress reporting is disabled to prevent duplicate/incorrect reporting.
+      // The stdout buffer is still accumulated for use in final resolution logic (T-007).
+      /*
       if (onProgress && stdout.length > lastReportedLength) {
         const newContent = stdout.substring(lastReportedLength);
         lastReportedLength = stdout.length;
         onProgress(newContent);
       }
+      */
     });
 
     childProcess.stderr.on("data", (data) => {
+      // Accumulate stderr chunks as string (verified in T-003)
       stderr += data.toString();
-      
+
+      // Report stderr progress when structured markers detected
+      if (onProgress && hasStructuredMarkers(stderr) && stderr.length > lastReportedLengthStderr) {
+        const newContent = stderr.substring(lastReportedLengthStderr);
+        lastReportedLengthStderr = stderr.length;
+        onProgress(newContent);
+      }
+
       // Check for common Codex/OpenAI errors
       if (stderr.includes("UNAUTHENTICATED") || stderr.includes("authentication failed")) {
         Logger.authenticationStatus(false, "API key or login");
       }
-      
+
       if (stderr.includes("RESOURCE_EXHAUSTED") || stderr.includes("rate limit")) {
         Logger.error("Rate limit or quota exceeded");
       }
-      
+
       if (stderr.includes("PERMISSION_DENIED") || stderr.includes("sandbox")) {
         Logger.error("Sandbox permission denied");
       }
@@ -81,11 +120,63 @@ export async function executeCommand(
       if (!isResolved) {
         isResolved = true;
         if (timeoutHandle) clearTimeout(timeoutHandle);
-        
+
         if (code === 0) {
-          Logger.commandComplete(startTime, code, stdout.length);
-          resolve(stdout.trim());
+          /*
+           * Stream Selection Logic (US-001):
+           *
+           * Unix Convention:
+           * - stdout: Clean output intended for piping/processing
+           * - stderr: Diagnostic output, structured data, progress information
+           *
+           * Non-TTY Behavior:
+           * In non-TTY mode (MCP server context), Codex CLI writes structured output
+           * (headers, thinking, codex sections, tokens) to stderr, while stdout remains minimal.
+           * This is standard Unix practice - structured diagnostic/progress information goes to stderr
+           * so stdout remains clean for downstream processing.
+           *
+           * Selection Flow:
+           * 1. Detect structured markers (--------/thinking/codex) in stderr
+           * 2. If detected AND stderr non-empty after trimming → use stderr
+           * 3. Otherwise → fallback to stdout (backward compatibility)
+           *
+           * Rationale:
+           * - When Codex CLI runs in MCP context (non-TTY), it intentionally outputs
+           *   structured data to stderr following Unix conventions
+           * - We detect this structured output by looking for known markers
+           * - Empty check prevents returning empty strings when markers exist but no content
+           * - Stdout fallback ensures compatibility with commands that don't use structured output
+           *
+           * See docs/fixplan.md for detailed technical design (Option 1 approach)
+           */
+
+          // T-006: Detect if stderr contains structured output markers
+          // T-007: Resolve with stderr when structured markers detected, fallback to stdout otherwise
+          // In non-TTY mode, Codex CLI writes structured output (headers, thinking, codex, tokens) to stderr
+          const hasStructuredOutput = hasStructuredMarkers(stderr);
+
+          // T-009: Debug logging for stream selection
+          Logger.debug(`Stream selection: structured markers detected=${hasStructuredOutput}`);
+          Logger.debug(`Selecting ${hasStructuredOutput ? 'stderr' : 'stdout'} for resolution`);
+
+          // T-008: Capture selected output to report correct length in metrics
+          // T-010: Fallback behavior explanation:
+          // - When structured markers are detected (--------/thinking/codex), use stderr
+          //   because Codex CLI writes structured output to stderr in non-TTY mode
+          // - When no structured markers are detected, fallback to stdout
+          //   for backward compatibility with commands that don't produce structured output
+          // T-011: Handle edge case where stderr has markers but is empty after trimming
+          // If stderr is empty, fallback to stdout to ensure non-empty output when possible
+          const trimmedStderr = stderr.trim();
+          const output = (hasStructuredOutput && trimmedStderr) ? trimmedStderr : stdout.trim();
+          Logger.commandComplete(startTime, code, output.length);
+          resolve(output);
         } else {
+          // T-012: Error path verification - confirmed unchanged after T-007 and T-011 success path modifications
+          // This error path correctly:
+          // - Uses stderr.trim() for error messages with fallback to "Unknown error"
+          // - Logs completion with exit code and error message
+          // - Rejects promise with exit code and stderr-based error message
           Logger.commandComplete(startTime, code ?? undefined);
           Logger.error(`Failed with exit code ${code}`);
           const errorMessage = stderr.trim() || "Unknown error";
@@ -95,6 +186,13 @@ export async function executeCommand(
     });
 
     // Handle process termination
+    // T-015: Signal handler compatibility verified with T-007 stream selection changes
+    // - Signal handlers operate independently at process termination level (lines 189-199)
+    // - Stream selection logic is in close handler (lines 119-186) - no interaction
+    // - Handlers check isResolved flag to prevent duplicate cleanup (consistent with timeout/error handlers)
+    // - Compatible with T-007 stderr preference: handlers don't touch stdout/stderr buffers
+    // - Note: Signal handlers follow simplified pattern (check flag + kill) vs timeout handler
+    //   (set flag + kill + log + reject). Close handler will still execute after signal.
     process.on('SIGINT', () => {
       if (!isResolved) {
         childProcess.kill('SIGTERM');


### PR DESCRIPTION
## Problem

The Codex CLI MCP tool was not correctly capturing structured output from Codex commands. When Codex writes structured responses (containing markers like `--------`, `thinking`, or `codex`) to stderr, the tool was defaulting to stdout, resulting in empty or incorrect responses being returned to Claude Code.

## Solution

Implemented stderr-first resolution logic that:
1. **Detects structured markers** in stderr using a new `hasStructuredMarkers()` function
2. **Prioritizes stderr** when structured output is detected, even if stdout has content
3. **Maintains backward compatibility** by falling back to stdout when no markers are present
4. **Preserves all existing behavior** for error handling, timeouts, and signal handling

## Changes

- **`src/utils/commandExecutor.ts`**: Added structured marker detection and stderr-first resolution
- **`src/utils/__tests__/commandExecutor.test.ts`**: Comprehensive test suite covering all edge cases
- **`scripts/verify-stderr-resolution.ts`**: Manual verification script demonstrating the fix

## Testing

- ✅ Unit tests for `hasStructuredMarkers()` function (all marker types)
- ✅ Integration tests for stream resolution logic (10+ scenarios)
- ✅ Manual verification script confirms correct behavior
- ✅ Backward compatibility verified (error paths, timeouts, signals unchanged)

## Impact

This fix restores the ability for Claude Code to receive properly formatted Codex responses through the MCP integration, enabling structured reasoning and output display.


## Note

Confirmed working with Claude Code `2.0.29` and OpenAI Codex `0.50.0`.